### PR TITLE
Revert changes regarding robfig/cron

### DIFF
--- a/cronjobs.go
+++ b/cronjobs.go
@@ -78,7 +78,7 @@ func (scheduler *scheduler) ReadFiles(dirname string) error {
 				Duration: time.Since(start),
 			}
 		}
-		if _, err := scheduler.AddFunc(spec, runFunc); err != nil {
+		if err := scheduler.AddFunc(spec, runFunc); err != nil {
 			return fmt.Errorf(`File %s: %s`, fPath, err)
 		}
 	}


### PR DESCRIPTION
Somehow the changes regarding `robfig/cron` is no longer required.

I believe that the changes on master were reverted, but no trace about it was found.

Signed-off-by: Wesley Galdino <wesleygaldino@gmail.com>