### PR TITLE
Pin version to v3 of robfig’s cron

### DIFF
--- a/cronjobs.go
+++ b/cronjobs.go
@@ -79,7 +79,7 @@ func (s *scheduler) ReadFiles(dirname string) error {
 				Duration: time.Since(start),
 			}
 		}
-		if err := s.AddFunc(spec, runFunc); err != nil {
+		if _, err := s.AddFunc(spec, runFunc); err != nil {
 			return fmt.Errorf(`File %s: %s`, fPath, err)
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dewey/cronjobs
+module github.com/db-journey/cronjobs
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/dewey/cronjobs
+
+go 1.12
+
+require (
+	github.com/db-journey/migrate v2.0.0+incompatible
+	github.com/robfig/cron/v3 v3.0.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/db-journey/migrate v2.0.0+incompatible h1:heh263YgHne8Fp+XvgDf427MjfB4jV1W19O+7vqU3pU=
+github.com/db-journey/migrate v2.0.0+incompatible/go.mod h1:mJTA43EQJ94pqUpLXH0qsTgn7OnO56iLy2q5ywaYUy4=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=


### PR DESCRIPTION
Hey,

looking at the latest commits you are aware of the changes to the robfig library. There was another change 3 days ago changing the default branch (https://github.com/robfig/cron/issues/213) which now breaks this again I think.

Maybe it would be best to pin the version directly so it doesn't depend on the what's currently set as the master on that repository.

If you prefer to do it another way feel free to throw this away but right now it's causing issue if you want to run journey.
