### PR TITLE
Add pinned version of robfig to import

### DIFF
--- a/cronjobs.go
+++ b/cronjobs.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/db-journey/migrate/driver"
-	"github.com/robfig/cron"
+	"github.com/robfig/cron/v3"
 )
 
 type scheduler struct {


### PR DESCRIPTION
Since we recently pinned a version of `robfig` for the pipelines to succeed we need to make sure that we import the right version in the `cronjobs.go` file.